### PR TITLE
헤로쿠에 배포하기 - DB 변경 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,7 +47,7 @@ spring:
     activate:
       on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
   sql:
     init:
       mode: always


### PR DESCRIPTION
ClearDB의 기본 MySQL 버전 5.6이 너무 낮아 기본 버전이 8.0인 JawsDB로 변경함.
(5.6 버전에서 `article_comment_content` 인덱스 사이즈가 너무 큼)

Fixes #51 

* https://devcenter.heroku.com/articles/cleardb#the-cleardb-dedicated-mysql-complete-tutorial-local-setup
* https://devcenter.heroku.com/articles/jawsdb